### PR TITLE
fix missing film_images_url config

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -27,6 +27,7 @@ module Keepit
     config.book_api_url = "https://www.googleapis.com/books/v1/volumes"
 
     config.film_api_url = "https://api.themoviedb.org"
+    config.film_images_url = "https://image.tmdb.org/t/p"
     config.film_api_version = 3
 
     config.api_version = "1.0"


### PR DESCRIPTION
There was a config which was missing to film images url feature